### PR TITLE
Shares submitted for past blocks no longer recorded, fix network diff…

### DIFF
--- a/lib/charts.js
+++ b/lib/charts.js
@@ -66,7 +66,23 @@ var chartStatFuncs = {
 // Statistic value handler
 var statValueHandler = {
     avg: function(set, value) {
-        set[1] = (set[1] * set[2] + value) / (set[2] + 1);
+
+        // avg function was returning weird numbers due to integer overflow when multiplying large numbers
+        // orginal avg function calculation : set[1] = (set[1] * set[2] + value) / (set[2] + 1);
+        // Below we convert the orginal calculation into separate steps that use the bignum library methods
+
+        var product = bignum(set[2]).mul(set[1]);
+        var valueBigNum = bignum(value);
+        var numerator = product.add(valueBigNum);
+        var denominator = bignum(set[2]).add(1);
+        var answer = numerator.div(denominator);
+
+        set[1] = answer;
+
+        // console.log("answer  = " + answer.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ","));
+
+        // set[1] = (set[1] * set[2] + value) / (set[2] + 1);
+
     },
     avgRound: function(set, value) {
         statValueHandler.avg(set, value);
@@ -198,10 +214,10 @@ function getNetworkDifficulty(callback) {
 
         var difficulty = stats.network.difficulty;
 
-        if (stats.network.height >= CASH2_HARD_FORK_HEIGHT_2)
-        {
-          difficulty = bignum('1099511627776').mul(stats.network.difficulty);
-        }
+        // if (stats.network.height >= CASH2_HARD_FORK_HEIGHT_2)
+        // {
+          // difficulty = bignum('1099511627776').mul(stats.network.difficulty);
+        // }
 
         callback(error, stats.pool ? difficulty : null);                                          
     });
@@ -323,10 +339,10 @@ function getCoinProfit(callback) {
 
             var difficulty = stats.network.difficulty;
 
-            if (stats.network.height >= CASH2_HARD_FORK_HEIGHT_2)
-            {
-              difficulty = bignum('1099511627776').mul(stats.network.difficulty);
-            }
+            // if (stats.network.height >= CASH2_HARD_FORK_HEIGHT_2)
+            // {
+              // difficulty = bignum('1099511627776').mul(stats.network.difficulty);
+            // }
 
             callback(null, stats.lastblock.reward * price / difficulty / config.coinUnits);
         });

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -8,6 +8,7 @@
 var extraNonce1Global = 0;
 
 redisClient.set("currentBlockHeight", -1);
+redisClient.set("currentBlockHeight2", -1);
 
 // Load required modules
 var fs = require('fs');
@@ -42,9 +43,9 @@ var log = function(severity, system, text, data){
 // Set cash2 algorithm
 var algorithm = "cash2";
 var blobType = 0;
-                                        
+
 // Set instance id
-                                    
+
 // Pool variables
 var poolStarted = false;
 var connectedMiners = {};
@@ -186,12 +187,12 @@ function BlockTemplate(template){
   this.difficulty = difficulty;
   this.height = template.height;
   this.reserveOffset = template.reserved_offset;
-  this.buffer = new Buffer(this.blob, 'hex');             
+  this.buffer = new Buffer(this.blob, 'hex');
   this.previousBlockHash = template.blocktemplate_blob.substr(0, 64); // previous block hash is 32 bytes long or 64 hex characters
   this.timestamp = template.blocktemplate_blob.substr(80, 16); // timestamp is 8 bytes long or 16 hex characters
 
-  var coinbaseEnd = template.coinbase_tx.length;                                                                                                                                                                                                                                                  
-  this.coinbaseTransaction1 = template.coinbase_tx.substr(coinbaseEnd - 240, (2 * template.reserved_offset - 160 - (coinbaseEnd - 240 + 2))); // 160 is from 80 byte header size times 2, 240 is the number of hex characters we want for coinbase transaction 1 + extra nonce 1 + extra nonce 2 + coinbase transaction 2                                                                                                                                                         
+  var coinbaseEnd = template.coinbase_tx.length;
+  this.coinbaseTransaction1 = template.coinbase_tx.substr(coinbaseEnd - 240, (2 * template.reserved_offset - 160 - (coinbaseEnd - 240 + 2))); // 160 is from 80 byte header size times 2, 240 is the number of hex characters we want for coinbase transaction 1 + extra nonce 1 + extra nonce 2 + coinbase transaction 2
   this.coinbaseTransaction2 = template.coinbase_tx.substr(2 * template.reserved_offset - 160 - 2 + 16); // 2 x reserve_offset - 160 - 2 gives the start of extra nonce 1.  16 is the size of extra nonce 1 plus extra nonce 2
 
   this.transactionHashes = template.transaction_hashes;
@@ -289,22 +290,30 @@ function jobRefresh(loop, callback){
     // getblocktemplate returns a block that is different from the one we are currently working on
     if (!currentBlockTemplate || result.height > currentBlockTemplate.height)
     {
-                                                                             
+
+      var redisCommands = [
+        ['set', "currentBlockHeight", result.height],
+        ['set', "currentBlockHeight2", result.height],
+      ];
+
       // save new block height into redis then call processBlockTemplate()
-      redisClient.set("currentBlockHeight", result.height, function (redisError) {
+      // redisClient.set("currentBlockHeight", result.height, function (redisError) {
+
+      redisClient.multi(redisCommands).exec(function(redisError) {
+
         if (redisError)
         {
           log('error', logSystem, 'Error saving block height into redis');
         }
 
         var difficulty = result.difficulty;
-                                                                            
+
         if (result.height >= CASH2_HARD_FORK_HEIGHT_2)
         {
           difficulty = bignum('1099511627776').mul(result.difficulty);
         }
-                                                                                 
- 
+
+                                                      
         log('info', logSystem, 'New block to mine at height %d w/ difficulty of %d', [result.height, difficulty]);
         processBlockTemplate(result);
       });
@@ -478,7 +487,7 @@ Miner.prototype = {
     {
       this.validJobs.shift();
     }
-                                         
+
     return {
       blob: blob,
       timestamp: currentBlockTemplate.timestamp,
@@ -918,7 +927,7 @@ function handleMinerMethod(method, params, socket, portData, sendReply, id)
  **/
 function newConnectedWorker(miner){
   log('info', logSystem, 'Miner connected %s@%s on port', [miner.login, miner.ip, miner.port]);
-                                                                                                        
+  
   if (miner.workerName !== 'undefined')
   {
     log('info', logSystem, 'Worker Name: %s', [miner.workerName]);
@@ -1135,7 +1144,7 @@ function processShare(miner, job, blockTemplate, nonce, extraNonce2, timestamp, 
   template.write(extraNonce1And2, blockTemplate.reserveOffset - 1, 16, "hex");
   
   // Get hash list root
-
+  
   // Coinbase transaction hash
   var h = blake2.createHash('blake2b', {digestLength: 32});
   var arbitraryTransactionBuffer = new Buffer("00" + job.coinbaseTransaction1 + extraNonce1And2 + job.coinbaseTransaction2, "hex");
@@ -1184,6 +1193,7 @@ function processShare(miner, job, blockTemplate, nonce, extraNonce2, timestamp, 
 
   // console.log('\x1b[32m', 'blockTemplate.difficulty = ' + blockTemplate.difficulty,'\x1b[0m');
   console.log('\x1b[32m', 'hashDiff = ' + hashDiff.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ","),'\x1b[0m');
+  // console.log('\x1b[32m', 'blockHeight = ' + job.height.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ","),'\x1b[0m');
 
   // block hash meets the difficulty requirements
   if (hashDiff.ge(blockTemplate.difficulty))
@@ -1192,39 +1202,53 @@ function processShare(miner, job, blockTemplate, nonce, extraNonce2, timestamp, 
     // We have to use redis to store the current block height to prevent multiple threads
     // from submitting blocks at the same height.
     // We were getting many "Error submitting block" errors due to submitting multiple blocks for the
-    // same height by the different threads, and clogging up the network.
-    // Blocks were not being processed fast enough with the clogged up network, and blocks were being
-    // processed slower than 9 seconds.
+    // same height by the different threads, and clogging up the network.                                    
     // We use redis as kind of like a mutex where the current block height can only be accessed by one
     // thread at a time.
-    // This way, if a block has already been submitted a block at a height, the current block height
-    // is set in redis to -1 and when another thread sees this, it is not allowed to submit its block
-
+                                                                                                    
     // get the value of the current block height from redis and store it in the variable currentBlockHeight
     redisClient.get("currentBlockHeight", function (redisError1, currentBlockHeight) {
       if (redisError1)
       {
         log('error', logSystem, 'Error getting block height from redis');
+        return false;
       }
 
       var currentBlockHeightSave = currentBlockHeight;
-                                                 
+    
       if (currentBlockHeight == job.height)
       {
+        var redisCommands1 = [
+          ['set', "currentBlockHeight", -1],
+          ['set', "currentBlockHeight2", -1],
+        ];
+
         // set the value of the current block height in redis to -1 then call submitblock
-        redisClient.set("currentBlockHeight", -1, function (redisError2) {
+        redisClient.multi(redisCommands1).exec(function(redisError2) {
+        
+        // redisClient.set("currentBlockHeight", -1, function (redisError2) {
+        
           if (redisError2)
           {
             log('error', logSystem, 'Error setting block height in redis');
+            return false;
           }
 
           // currentBlockHeightGlobal = -1;
-                                       
+
           apiInterfaces.rpcDaemon('submitblock', [shareBuffer.toString('hex')], function(error, result){
             if (error)
             {
+              var redisCommands2 = [
+                ['set', "currentBlockHeight", currentBlockHeightSave],
+                ['set', "currentBlockHeight2", currentBlockHeightSave],
+              ];
+
               // set the value of the current block height in redis back to the original value then send error response to the miner
-              redisClient.set("currentBlockHeight", currentBlockHeightSave, function (redisError3) {
+
+              // redisClient.set("currentBlockHeight", currentBlockHeightSave, function (redisError3) {
+              redisClient.multi(redisCommands2).exec(function(redisError3) {
+
                 if (redisError3)
                 {
                   log('error', logSystem, 'Error setting block height in redis');
@@ -1233,6 +1257,7 @@ function processShare(miner, job, blockTemplate, nonce, extraNonce2, timestamp, 
                 // currentBlockHeightGlobal = job.height;
 
                 log('error', logSystem, 'Error submitting block %s at height %d from %s@%s, share type: "%s" - %j', [blockFastHash, job.height, miner.login, miner.ip, shareType, error]);
+                
                 recordShareData(miner, job, hashDiff.toString(), false, null, shareType);
 
                 // send error response to miner
@@ -1263,15 +1288,16 @@ function processShare(miner, job, blockTemplate, nonce, extraNonce2, timestamp, 
               socket.write(sendData);
 
               recordShareData(miner, job, hashDiff.toString(), true, blockFastHash, shareType, blockTemplate);
+              
               jobRefresh(false);
             }
           });
         });
       }
-      else
-      {
-        recordShareData(miner, job, hashDiff.toString(), false, null, shareType);
-      }
+      // else
+      // {
+        // recordShareData(miner, job, hashDiff.toString(), false, null, shareType);
+      // }
     });
   }
   else if (hashDiff.lt(job.difficulty))
@@ -1279,8 +1305,21 @@ function processShare(miner, job, blockTemplate, nonce, extraNonce2, timestamp, 
     log('warn', logSystem, 'Rejected low difficulty share of %s from %s@%s', [hashDiff.toString(), miner.login, miner.ip]);
     return false;
   }
-  else{
-    recordShareData(miner, job, hashDiff.toString(), false, null, shareType);
+  else
+  {
+    redisClient.get("currentBlockHeight2", function (redisError, currentBlockHeight) {
+      if (redisError)
+      {
+        log('error', logSystem, 'Error getting block height from redis');
+        return false;
+      }
+
+      if (currentBlockHeight == job.height)
+      {
+        recordShareData(miner, job, hashDiff.toString(), false, null, shareType);
+      }
+      
+    });
   }
 
   return true;

--- a/lib/telegramBot.js
+++ b/lib/telegramBot.js
@@ -114,10 +114,10 @@ function sendPoolStats(chatId) {
 
         var difficulty = stats.network.difficulty;
 
-        if (stats.network.height >= CASH2_HARD_FORK_HEIGHT_2)
-        {
-          difficulty = bignum('1099511627776').mul(stats.network.difficulty);
-        }
+        // if (stats.network.height >= CASH2_HARD_FORK_HEIGHT_2)
+        // {
+          // difficulty = bignum('1099511627776').mul(stats.network.difficulty);
+        // }
 
         var poolHost = config.poolHost || "Pool";
         var poolHashrate = utils.getReadableHashRate(stats.pool.hashrate);


### PR DESCRIPTION
…iculty chart

1.Shares submitted for past blocks no longer recorded

Problem: miner's hashrate seen by pool was high and caused high estimated payouts

Cause: shares for blocks that have already been found were still begin recorded as valid shares. This is caused by a network lag between when a valid block is submitted and when a pool can notify all miners that the block has been found.

Solution: Shares for blocks that have already been found are no longer recorded.

2. Fix network difficulty chart

Problem : network difficulty chart has strange values due to interger overflow

Cause: calculating the average of 2 difficulties in chart.js caused integer overflow

Solution : use bignum nodejs library to help calculate averages of 2 difficulties